### PR TITLE
#13 add documentation lookup

### DIFF
--- a/src/elixirHoverProvider.ts
+++ b/src/elixirHoverProvider.ts
@@ -1,0 +1,21 @@
+import * as vscode from 'vscode';
+import { ElixirServer } from './elixirServer';
+
+export class ElixirHoverProvider implements vscode.HoverProvider {
+
+  constructor(private server: ElixirServer) { }
+
+  provideHover(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): Thenable<vscode.Hover> {
+    return new Promise((resolve, reject) => {
+      this.server.getDocumentation(document, position, (hover: vscode.Hover) => {
+        if (!token.isCancellationRequested) {
+          resolve(hover);
+        } else {
+          console.error('rejecting');
+          reject();
+        }
+      });
+
+    });
+  }
+}

--- a/src/elixirMain.ts
+++ b/src/elixirMain.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { ElixirAutocomplete } from './elixirAutocomplete';
 import { ElixirServer } from './elixirServer';
 import { ElixirDefinitionProvider } from './elixirDefinitionProvider';
+import { ElixirHoverProvider } from './elixirHoverProvider';
 import {configuration} from './elixirConfiguration';
 
 const ELIXIR_MODE: vscode.DocumentFilter = { language: 'elixir', scheme: 'file' };
@@ -12,6 +13,7 @@ export function activate(ctx: vscode.ExtensionContext) {
     this.elixirServer.start();
     ctx.subscriptions.push(vscode.languages.registerCompletionItemProvider(ELIXIR_MODE, new ElixirAutocomplete(this.elixirServer)));
     ctx.subscriptions.push(vscode.languages.registerDefinitionProvider(ELIXIR_MODE, new ElixirDefinitionProvider(this.elixirServer)));
+    ctx.subscriptions.push(vscode.languages.registerHoverProvider(ELIXIR_MODE, new ElixirHoverProvider(this.elixirServer)));
     ctx.subscriptions.push(vscode.languages.setLanguageConfiguration('elixir', configuration));
 }
 

--- a/src/elixirServer.ts
+++ b/src/elixirServer.ts
@@ -126,9 +126,12 @@ export class ElixirServer {
         }
         const command: string = `DOCL { "${word}", "${document.fileName}", ${position.line + 1} }\n`;
         const resultCb = (result: string) => {
-            console.log(result);
-            const hover = new vscode.Hover(result, wordAtPosition);
-            callback(hover);
+            if (result) {
+                const hover = new vscode.Hover(result, wordAtPosition);
+                callback(hover);
+            } else {
+                callback([]);
+            }
         }
         this.sendRequest('DOCL', command, resultCb);
     }

--- a/src/elixirServer.ts
+++ b/src/elixirServer.ts
@@ -116,6 +116,23 @@ export class ElixirServer {
         this.sendRequest('DEFL', command, resultCb);
     }
 
+    getDocumentation(document: vscode.TextDocument, position: vscode.Position, callback: Function): void {
+        const wordAtPosition = document.getWordRangeAtPosition(position);
+        const word = document.getText(wordAtPosition);
+        if (word.indexOf('\n') >= 0) {
+            console.error('[vscode-elixir] got whole file as word');
+            callback([]);
+            return;
+        }
+        const command: string = `DOCL { "${word}", "${document.fileName}", ${position.line + 1} }\n`;
+        const resultCb = (result: string) => {
+            console.log(result);
+            const hover = new vscode.Hover(result, wordAtPosition);
+            callback(hover);
+        }
+        this.sendRequest('DOCL', command, resultCb);
+    }
+
     createDefinitionLookup(word: string): string {
         if (word.indexOf('.') >= 0) {
             const words = word.split('.');


### PR DESCRIPTION
This commit/PR adds a HoverProvider to the plugin, which internally uses the alchemist-server command 'DOCL' to retrieve documentation of a symbol while hovering over it.