### PR TITLE
feat: Add test support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,11 @@ This extension adds elixir support for VSCode
 * Syntax Coloring
 * Snippets
 * Intellisense (thanks to [fr1zle](https://github.com/fr1zle))
+* Running tests
 
+## Commands
 
+* `Elixir: Test Project`
+* `Elixir: Run Current Test File`
+* `Elixir: Run Test at Cursor`
+* `Elixir: Re-run last test`

--- a/package.json
+++ b/package.json
@@ -90,11 +90,15 @@
         ]
     },
     "scripts": {
-        "vscode:prepublish": "node ./node_modules/vscode/bin/compile",
-        "compile": "node ./node_modules/vscode/bin/compile -watch -p ./"
+        "vscode:prepublish": "tsc -p ./",
+        "compile": "tsc -watch -p ./",
+        "postinstall": "node ./node_modules/vscode/bin/install"
     },
     "devDependencies": {
-        "typescript": "^1.6.2",
-        "vscode": "0.10.x"
+        "@types/node": "^6.0.40",
+        "@types/mocha": "^2.2.32",
+        "mocha": "^2.3.3",
+        "typescript": "^2.0.3",
+        "vscode": "^1.0.3"
     }
 }

--- a/package.json
+++ b/package.json
@@ -87,6 +87,24 @@
                 "language": "elixir",
                 "path": "./snippets/snippets.json"
             }
+        ],
+        "commands": [
+            {
+                "command": "elixir.test.cursor",
+                "title": "Elixir: Run Test at Cursor"
+            },
+            {
+                "command": "elixir.test.file",
+                "title": "Elixir: Run Current Test File"
+            },
+            {
+                "command": "elixir.test.project",
+                "title": "Elixir: Test Project"
+            },
+            {
+                "command": "elixir.test.previous",
+                "title": "Elixir: Re-run last test"
+            }
         ]
     },
     "scripts": {

--- a/src/elixirMain.ts
+++ b/src/elixirMain.ts
@@ -1,11 +1,11 @@
 import * as vscode from 'vscode';
 import { ElixirAutocomplete } from './elixirAutocomplete';
-import { ElixirServer } from './elixirServer';
+import { configuration } from './elixirConfiguration';
 import { ElixirDefinitionProvider } from './elixirDefinitionProvider';
-import {configuration} from './elixirConfiguration';
+import { ElixirServer } from './elixirServer';
+import { ElixirTest } from './elixirTest';
 
 const ELIXIR_MODE: vscode.DocumentFilter = { language: 'elixir', scheme: 'file' };
-let elixirServer: ElixirServer;
 
 export function activate(ctx: vscode.ExtensionContext) {
     this.elixirServer = new ElixirServer();
@@ -13,6 +13,20 @@ export function activate(ctx: vscode.ExtensionContext) {
     ctx.subscriptions.push(vscode.languages.registerCompletionItemProvider(ELIXIR_MODE, new ElixirAutocomplete(this.elixirServer)));
     ctx.subscriptions.push(vscode.languages.registerDefinitionProvider(ELIXIR_MODE, new ElixirDefinitionProvider(this.elixirServer)));
     ctx.subscriptions.push(vscode.languages.setLanguageConfiguration('elixir', configuration));
+
+    this.elixirTest = new ElixirTest();
+    ctx.subscriptions.push(vscode.commands.registerCommand('elixir.test.cursor', () => {
+        return this.elixirTest.testAtCursor();
+    }));
+    ctx.subscriptions.push(vscode.commands.registerCommand('elixir.test.file', () => {
+        return this.elixirTest.testCurrentFile();
+    }));
+    ctx.subscriptions.push(vscode.commands.registerCommand('elixir.test.previous', () => {
+        return this.elixirTest.testPrevious();
+    }));
+    ctx.subscriptions.push(vscode.commands.registerCommand('elixir.test.project', () => {
+        return this.elixirTest.testProject();
+    }));
 }
 
 export function deactivate() {

--- a/src/elixirServer.ts
+++ b/src/elixirServer.ts
@@ -56,15 +56,15 @@ export class ElixirServer {
             console.log('[vscode-elixir] exited', exitCode);
         });
         this.p.stdout.on('data', (chunk) => {
-            if (chunk.indexOf(`END-OF-${this.lastRequestType}`) > -1) {
-                const chunkString: string = chunk.toString();
+            const chunkString: string = chunk.toString();
+            if (chunkString.indexOf(`END-OF-${this.lastRequestType}`) > -1) {
                 const splitStrings: string[] = chunkString.split(`END-OF-${this.lastRequestType}`);
                 const result = (this.buffer + splitStrings[0]).trim();
                 this.resultCallback(result);
                 this.buffer = '';
                 this.busy = false;
             } else {
-                this.buffer += chunk.toString();
+                this.buffer += chunkString;
             }
         });
         this.p.stderr.on('data', (chunk: Buffer) => {

--- a/src/elixirTest.ts
+++ b/src/elixirTest.ts
@@ -1,0 +1,84 @@
+import * as vscode from 'vscode';
+import * as cp from 'child_process';
+
+export class ElixirTest {
+    cp: cp.ChildProcess;
+    lastTestArgs: string[];
+    outputChannel: vscode.OutputChannel;
+
+    constructor() {
+        // TODO: Maybe move this up and call it 'mix' or 'elixir'?
+        this.outputChannel = vscode.window.createOutputChannel('Elixir Test');
+    }
+
+    testAtCursor() {
+        const editor = this.currentTestEditor();
+        if (!editor) { return; };
+        const filePath = editor.document.fileName;
+        const lineNumber = editor.selection.start.line;
+        this.test([`${filePath}:${lineNumber}`]);
+    }
+
+    testCurrentFile() {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor) { return; };
+        this.test([editor.document.fileName]);
+    }
+
+    testPrevious() {
+        if (!this.lastTestArgs) {
+            vscode.window.showInformationMessage('No test has been recently executed.');
+            return;
+        }
+        this.test(this.lastTestArgs);
+    }
+
+    testProject() {
+        return this.test([]);
+    }
+
+    private test(args: string[]) {
+        this.lastTestArgs = args;
+        return new Promise((resolve, reject) => {
+            this.outputChannel.clear();
+            this.outputChannel.show(true);
+
+            const rootPath = vscode.workspace.rootPath;
+            if (!rootPath) {
+                vscode.window.showInformationMessage('No project is open.');
+                return;
+            }
+            this.cp = cp.spawn('mix', ['test'].concat(args), { cwd: vscode.workspace.rootPath });
+            this.cp.stdout.on(
+                'data',
+                chunk => this.outputChannel.append(chunk.toString())
+            );
+            this.cp.stderr.on(
+                'data',
+                chunk => this.outputChannel.append(chunk.toString())
+            );
+            this.cp.on('close', code => {
+                if (code) {
+                    this.outputChannel.append('Error: Tests failed.');
+                } else {
+                    this.outputChannel.append('Success: Tests passed.');
+                }
+                resolve(code === 0);
+            });
+        });
+    }
+
+    private currentTestEditor(): vscode.TextEditor | undefined {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor) {
+            vscode.window.showInformationMessage('No editor is active.');
+            return;
+        }
+        // TODO: Make this pattern configurable (like mix test)
+        if (!editor.document.fileName.endsWith('_test.exs')) {
+            vscode.window.showInformationMessage('Current file is not a test file.');
+            return;
+        }
+        return editor;
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
 	"compilerOptions": {
 		"module": "commonjs",
-		"target": "ES5",
+		"target": "es6",
 		"outDir": "out",
-		"noLib": true,
+		"lib": [ "es6" ],
 		"sourceMap": true
 	},
 	"exclude": [

--- a/typings/node.d.ts
+++ b/typings/node.d.ts
@@ -1,1 +1,0 @@
-/// <reference path="../node_modules/vscode/typings/node.d.ts" />

--- a/typings/vscode-typings.d.ts
+++ b/typings/vscode-typings.d.ts
@@ -1,1 +1,0 @@
-/// <reference path="../node_modules/vscode/typings/index.d.ts" />


### PR DESCRIPTION
This PR adds support for test execution in an output pane. The commands provided are:
* `Elixir: Test Project`
* `Elixir: Run Current Test File`
* `Elixir: Run Test at Cursor`
* `Elixir: Re-run last test`

I think what they do is pretty self explanatory. Sadly currently the output panes have no syntax highlighting.

Please don't feel forced to pull this into the extension if you think this isn't in the scope of the project. In addition to that I would love feedback if you think the way the tests are integrated is handy or not.

If this high-level checks are out of the way please review. 😃

There aren't any tests for my code which is sad but I didn't came up with a good way to test this. I have to think about this some more.

NOTE: I updated the extension to newer versions of the vscode library and typescript. Let me know if this is a problem.

*Sidenote*: I used `tslint` with some basic rules for my new code but I neither commited the `tslint.json` not did update the old code. Let me know if you think we should adopt it in some form for the whole project.