### PR TITLE
Fixes for warnings in Elixir 1.4.2

### DIFF
--- a/alchemist-server/lib/api/comp.exs
+++ b/alchemist-server/lib/api/comp.exs
@@ -28,10 +28,10 @@ defmodule Alchemist.API.Comp do
     list2 = Complete.run(hint)
     first_item = Enum.at(list2, 0)
 
-    if first_item in [nil, ""] do
-      first_item = "#{hint};hint"
+    {first_item, list2} = if first_item in [nil, ""] do
+      {"#{hint};hint", list2}
     else
-      list2 = List.delete_at(list2, 0)
+      {first_item, List.delete_at(list2, 0)}
     end
 
     full_list = [first_item] ++ find_attributes(attributes, hint) ++ find_vars(vars, hint) ++ list1 ++ list2

--- a/alchemist-server/lib/code/state.exs
+++ b/alchemist-server/lib/code/state.exs
@@ -70,9 +70,10 @@ defmodule Alchemist.Code.State do
     new_state = state |> add_mod_fun_to_line({current_module, func, arity}, line)
 
     if !Map.has_key?(state.mods_funs_to_lines, {current_module, func, nil}) do
-      new_state = new_state |> add_mod_fun_to_line({current_module, func, nil}, line)
+      new_state |> add_mod_fun_to_line({current_module, func, nil}, line)
+    else
+      new_state
     end
-    new_state
   end
 
   def new_alias_scope(state) do

--- a/alchemist-server/lib/helpers/introspection.exs
+++ b/alchemist-server/lib/helpers/introspection.exs
@@ -89,15 +89,12 @@ defmodule Introspection do
   end
 
   defp get_callbacks_with_docs(mod) when is_atom(mod) do
-    case get_callbacks_and_docs(mod) do
-      {callbacks, docs} ->
-        Enum.filter_map docs, &match?(_, &1), fn
-          {{fun, arity}, _, :macrocallback, doc} ->
-            get_callback_with_doc(fun, :macrocallback, doc, {:"MACRO-#{fun}", arity + 1}, callbacks)
-          {{fun, arity}, _, kind, doc} ->
-            get_callback_with_doc(fun, kind, doc, {fun, arity}, callbacks)
-        end
-      _ -> []
+    {callbacks, docs} = get_callbacks_and_docs(mod)
+    Enum.map docs, fn
+      {{fun, arity}, _, :macrocallback, doc} ->
+        get_callback_with_doc(fun, :macrocallback, doc, {:"MACRO-#{fun}", arity + 1}, callbacks)
+      {{fun, arity}, _, kind, doc} ->
+        get_callback_with_doc(fun, kind, doc, {fun, arity}, callbacks)
     end
   end
 

--- a/alchemist-server/lib/server.exs
+++ b/alchemist-server/lib/server.exs
@@ -127,4 +127,8 @@ defmodule Alchemist.Server do
   defp purge_apps(apps) do
     for a <- apps, do: Application.unload(a)
   end
+
+  def version() do
+    @version
+  end
 end


### PR DESCRIPTION
With the latest version of Elixir there are multiple warnings triggered by `alchemist-server`. This PR contains small changes in the code to avoid those warnings and that do not affect the existing functionality.

Ideally this PR would be proposed in the `alchemist-server` repo itself, however I have noticed the `master` branch in that repo differs quite a lot from the one we depend on here (e.g. `alchemist-server` does not support passing files as parameters as the in-built parser has been removed).

This would be just a patch to keep this extension working while a more permanent solution is implemented.