### PR TITLE
Add support for ProblemMatcher for mix tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,5 +98,45 @@
         "typescript": "^1.6.2",
         "vsce": "^1.18.0",
         "vscode": "0.10.x"
+    },
+    "contributes": {
+        "problemMatchers": [
+            {
+                "name": "mixCompileError",
+                "owner": "elixir",
+                "fileLocation": ["relative", "${workspaceRoot}"],
+                "severity": "error",
+                "pattern": {
+                    "regexp": "^\\*\\* \\((\\w+)\\) (.*):(\\d+): (.*)$",
+                    "file": 2,
+                    "location": 3,
+                    "message": 0
+                }
+            },
+            {
+                "name": "mixCompileWarning",
+                "owner": "elixir",
+                "fileLocation": ["relative", "${workspaceRoot}"],
+                "severity": "warning",
+                "pattern": {
+                    "regexp": "^warning: (.*)$",
+                    "message": 1
+                }
+            },
+            {
+                "name": "mixTestFailure",
+                "owner": "elixir",
+                "fileLocation": ["relative", "${workspaceRoot}"],
+                "severity": "warning",
+                "pattern":  [{
+                    "regexp": "^  \\d+\\) (.*)$",
+                    "message": 1
+                },{
+                    "regexp": "^     (.*):(\\d+)$",
+                    "file": 1,
+                    "location": 2
+                }]
+            }
+        ]
     }
 }


### PR DESCRIPTION
VSCode 1.11 added support for custom ProblemMatchers in tasks. When tasks are run from the task runner, file and line info from mix tests, and mix compile warnings/errors are presented to the user.

Here's some sample usage for `.vscode/tasks.json` to test:

```
{
    // See https://go.microsoft.com/fwlink/?LinkId=733558
    // for the documentation about the tasks.json format
    "version": "0.1.0",
    "command": "mix",
    "isShellCommand": true,
    "showOutput": "always",
    "suppressTaskName": true,
    "tasks": [
        {
            "taskName": "build",
            "args": ["compile"],
            "problemMatcher": ["$mixCompileError","$mixCompileWarning"],
            "isBuildCommand": true
        },
        {
            "taskName": "test",
            "args": ["test"],
            "problemMatcher": ["$mixCompileError","$mixCompileWarning","$mixTestFailure"],
            "isTestCommand": true
        }
    ]
}
```