### PR TITLE
Added configuration file for html.exx files

### DIFF
--- a/html.exx.configuration.json
+++ b/html.exx.configuration.json
@@ -1,0 +1,26 @@
+{
+	"comments": {
+		"blockComment": [ "<!--", "-->" ]
+	},
+	"brackets": [
+		["<!--", "-->"],
+		["<", ">"],
+		["{", "}"],
+		["(", ")"]
+	],
+	"autoClosingPairs": [
+		{ "open": "{", "close": "}"},
+		{ "open": "[", "close": "]"},
+		{ "open": "(", "close": ")" },
+		{ "open": "'", "close": "'" },
+		{ "open": "\"", "close": "\"" }
+	],
+	"surroundingPairs": [
+		{ "open": "'", "close": "'" },
+		{ "open": "\"", "close": "\"" },
+		{ "open": "{", "close": "}"},
+		{ "open": "[", "close": "]"},
+		{ "open": "(", "close": ")" },
+		{ "open": "<", "close": ">" }
+	]
+}

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
                 ],
                 "extensions": [
                     ".html.eex"
-                ]
+                ],
+                "configuration": "./html.exx.configuration.json"
             }
         ],
         "grammars": [


### PR DESCRIPTION
This allows using the comment shortcut(ctrl+/ or cmd+/), as well as have auto-closing brackets/quotes/parentheses. This configuration file is directly taken from the [default html version](https://github.com/Microsoft/vscode/blob/master/extensions/html/language-configuration.json). I tested it, and it seems to work fine.