### PR TITLE
Updated html eex configuration semantics to use true comments

### DIFF
--- a/html.eex.configuration.json
+++ b/html.eex.configuration.json
@@ -1,19 +1,21 @@
 {
 	"comments": {
-		"blockComment": [ "<!--", "-->" ]
+		"blockComment": [ "<%#", "%>" ]
 	},
 	"brackets": [
-		["<!--", "-->"],
 		["<", ">"],
 		["{", "}"],
-		["(", ")"]
+		["(", ")"],
+		["[", "]"]
 	],
 	"autoClosingPairs": [
 		{ "open": "{", "close": "}"},
 		{ "open": "[", "close": "]"},
 		{ "open": "(", "close": ")" },
-		{ "open": "'", "close": "'" },
-		{ "open": "\"", "close": "\"" }
+		{ "open": "'", "close": "'", "notIn": ["string", "comment"] },
+		{ "open": "\"", "close": "\"" },
+		{ "open": "<", "close": ">" },
+		{ "open": "%", "close": "%", "notIn": ["string", "comment"] }
 	],
 	"surroundingPairs": [
 		{ "open": "'", "close": "'" },
@@ -21,6 +23,7 @@
 		{ "open": "{", "close": "}"},
 		{ "open": "[", "close": "]"},
 		{ "open": "(", "close": ")" },
-		{ "open": "<", "close": ">" }
+		{ "open": "<", "close": ">" },
+		{ "open": "%", "close": "%" }
 	]
 }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
                 "extensions": [
                     ".html.eex"
                 ],
-                "configuration": "./html.exx.configuration.json"
+                "configuration": "./html.eex.configuration.json"
             }
         ],
         "grammars": [


### PR DESCRIPTION
I just noticed a couple issues with the last PR I submitted( #84 ). The first is that I used HTML comments which are not semantically the same as eex comments. HTML comments will be preserved in HTML that is served up, while eex comments will not. Also I spelled eex as exx in two places. I fixed both of these issues and added a couple extra autoclosing/surrounding pairs. Sorry for the issues...