### PR TITLE
Quote path parameters on Windows when launching ElixirSense

### DIFF
--- a/src/elixirSenseServerProcess.ts
+++ b/src/elixirSenseServerProcess.ts
@@ -80,7 +80,10 @@ export class ElixirSenseServerProcess {
 
         if (process.platform === 'win32') {
             options.windowsVerbatimArguments = true;
-            return spawn('cmd', ['/s', '/c', `"${[this.command].concat(this.args).concat('tcpip', port, env).join(' ')}"`], options);
+
+            // quote all args in case they contain spaces in their paths. the ^ is the escape character; ^" is cmd.exe-speak for \".
+            const args = this.args.map(arg => `^"${arg}^"`);
+            return spawn('cmd', ['/s', '/c', `"${[this.command].concat(args).concat('tcpip', port, env).join(' ')}"`], options);
         } else {
             return spawn(this.command, this.args.concat('unix', port, env), options);
         }


### PR DESCRIPTION
Hi! Thanks for great work. However, the intellisense wouldn't load on my box, and I discovered that it was because my Windows username contains a space, it got installed in

    C:\Users\Max Planckton\.vscode\extensions\mjmcloug.vscode-elixir-yadayada

This, in turn, made ElixirSense not load, I got a `can't find path C:\Users\Max` type of error (sorry, forgot to copy the exact error message). I'm convinced that every Windows user who has a "firstname lastname" username will have this problem. Anyway, I figured that it's better to fix it than complain, so here goes.

Spaces in cmd.exe are a pain, but I think I made a pretty failsafe workaround here. Let me know what you think.