### PR TITLE
Command to run iex loading in selected code

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,10 +173,10 @@
     "devDependencies": {
         "tslint": "^5.5.0",
         "typescript": "^2.1.0",
-        "mocha": "^2.3.3",
+        "mocha": "^3.5.0",
         "vsce": "^1.22.0",
         "vscode": "^1.1.4",
         "@types/node": "^6.0.40",
-        "@types/mocha": "^2.2.32"
+        "@types/mocha": "^2.2.42"
     }
 }

--- a/package.json
+++ b/package.json
@@ -161,6 +161,16 @@
                     "description": "Project environment"
                 }
             }
+        },
+        "commands": [{
+            "command": "vscode-elixir.runInIex",
+            "title": "Run in iex"
+        }],
+        "menus": {
+            "commandPalette": [{
+                "when": "resourceLangId == elixir",
+                "command": "vscode-elixir.runInIex"
+          }]
         }
     },
     "scripts": {

--- a/src/elixirMain.ts
+++ b/src/elixirMain.ts
@@ -51,6 +51,26 @@ export function activate(ctx: vscode.ExtensionContext) {
         ctx.subscriptions.push(vscode.languages.registerHoverProvider(ELIXIR_MODE, new ElixirHoverProvider(this.elixirServer)));
         ctx.subscriptions.push(vscode.languages.setLanguageConfiguration('elixir', configuration));
     }
+
+    let terminal;
+    let runInIex = vscode.commands.registerCommand('vscode-elixir.runInIex', () => {
+        let editor = vscode.window.activeTextEditor;
+        let selection = editor.selection;
+        let text = selection.isEmpty ? editor.document.getText() : editor.document.getText(selection);
+
+        if (terminal !== undefined)
+        {
+            terminal.dispose();
+        }
+
+        terminal = vscode.window.createTerminal('iex');
+        terminal.sendText("iex", true);
+        terminal.sendText(text, true);
+        terminal.sendText("clear", true);
+        terminal.show();
+    });
+
+    ctx.subscriptions.push(runInIex);
 }
 
 export function deactivate() {


### PR DESCRIPTION
Not sure if others will find this useful so I'll leave it up to you to decide if it's worth pulling @fr1zle.

This just adds a command to the palette to load up iex on the inbuilt terminal. Either loading in the full file or the highlighted text, if any is selected. Means you can just load in one method and play with it in isolation (which I do a lot when learning)

See the below gif

![example](https://user-images.githubusercontent.com/2362687/29794801-70d78c60-8c41-11e7-8d60-515230fb123b.gif)
