### PR TITLE
merge latest elixir syntax file from atom

### DIFF
--- a/syntaxes/elixir.json
+++ b/syntaxes/elixir.json
@@ -105,12 +105,33 @@
       "name": "constant.other.symbol.elixir"
     },
     {
-      "match": "(?<!\\.)\\b(do|end|case|bc|lc|for|if|cond|with|unless|try|receive|fn|defmodule|defprotocol|defimpl|defrecord|defstruct|defdelegate|defcallback|defexception|defoverridable|exit|after|rescue|catch|else|raise|throw|quote|unquote|super|when)\\b(?![?!])",
+      "match": "(?<!\\.)\\b(do|end|case|bc|lc|for|if|cond|with|unless|try|receive|fn|defmodule|defprotocol|defimpl|defrecordp?|defstruct|defdelegate|defcallback|defexception|defoverridable|exit|after|rescue|catch|else|raise|throw|quote|unquote|super|when|and|or|not|in)\\b(?![?!])",
       "name": "keyword.control.elixir"
     },
     {
-      "comment": "functions and arguments",
-      "match": "\\b(defp?|defmacrop?)\\b\\s*([_$a-zA-Z][$\\w]*[!?]?)?",
+      "comment": "Function with parameters",
+      "begin": "\\b(defp?|defmacrop?)\\b\\s*([_$a-z][$\\w]*[!?]?)\\s*\\(",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.elixir"
+        },
+        "2": {
+          "name": "entity.name.function.elixir"
+        }
+      },
+      "end": "\\)",
+      "patterns": [
+        {
+          "include": "$self"
+        },
+        {
+          "include": "#function_parameter"
+        }
+      ]
+    },
+    {
+      "comment": "Function without parameters",
+      "match": "\\b(defp?|defmacrop?)\\b\\s*([_$a-z][$\\w]*[!?]?)",
       "captures": {
         "1": {
           "name": "keyword.control.elixir"
@@ -1845,6 +1866,29 @@
       ]
     },
     {
+      "comment": "symbols with single-quoted string, used as keys in Keyword lists.",
+      "match": "(')((?:[^'\\\\]*(?:\\\\.[^'\\\\]*)*))(':)(?!:)",
+      "name": "constant.other.symbol.single-quoted.elixir",
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.constant.elixir"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#interpolated_elixir"
+            },
+            {
+              "include": "#escaped_char"
+            }
+          ]
+        },
+        "3": {
+          "name": "punctuation.definition.constant.elixir"
+        }
+      }
+    },
+    {
       "begin": ":\"",
       "captures": {
         "0": {
@@ -1935,6 +1979,29 @@
       ]
     },
     {
+      "comment": "symbols defined by double-quoted string, used as keys in Keyword lists.",
+      "match": "(\")((?:[^\"\\\\]*(?:\\\\.[^\"\\\\]*)*))(\":)(?!:)",
+      "name": "constant.other.symbol.double-quoted.elixir",
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.constant.elixir"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#interpolated_elixir"
+            },
+            {
+              "include": "#escaped_char"
+            }
+          ]
+        },
+        "3": {
+          "name": "punctuation.definition.constant.elixir"
+        }
+      }
+    },
+    {
       "begin": "\"",
       "beginCaptures": {
         "0": {
@@ -1987,7 +2054,7 @@
     },
     {
       "comment": "matches: | ++ -- ** \\ <- <> << >> :: .. |> => -> <|> <~> <~ <<~ ~> ~>>",
-      "match": "\\+\\+|\\-\\-|\\*\\*|\\\\\\\\|\\<\\-|<\\<\\~|\\<\\>|\\<\\<|\\>\\>|\\:\\:|\\.\\.|\\|>|=>|<\\|\\>|<~>|->|~>>|~>|<~",
+      "match": "\\+\\+|\\-\\-|\\*\\*|\\\\\\\\|\\<\\-|<\\<\\~|\\<\\>|\\<\\<|\\>\\>|\\:\\:|\\.\\.|\\|>|=>|<\\|\\>|<~>|->|~>>|~>|<~|(?<!\\|)\\|(?!\\|)",
       "name": "keyword.operator.other.elixir"
     },
     {
@@ -2067,6 +2134,10 @@
     "escaped_char": {
       "match": "\\\\(?:[0-7]{1,3}|x[\\da-fA-F]{1,2}|.)",
       "name": "constant.character.escape.elixir"
+    },
+    "function_parameter": {
+      "match": "[_$a-z][$\\w]*[?!]?",
+      "name": "parameter.variable.function.elixir"
     },
     "interpolated_elixir": {
       "patterns": [


### PR DESCRIPTION
I was wanting to apply syntax highlighting to function parameters and single/double quoted atoms (such as `"quoted-atom":`) which are now supported by the latest Elixir syntax file in Atom.

In merging the Atom file, I retained the recent commit https://github.com/fr1zle/vscode-elixir/commit/d905450864490f4fd5eb16932557b58b77199bc4 by @fr1zle which is the only code in this file that doesn't exactly track the Atom version.

Please let me know what you think and thanks for your work on this great extension!