### PR TITLE
Relax compile warning regex

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,9 +119,10 @@
                         "message": 1
                     },
                     {
-                        "regexp": "^  (.*):(\\d+)$",
+                        "regexp": "^  (.*):(\\d+)(.*)$",
                         "file": 1,
-                        "location": 2
+                        "location": 2,
+                        "message": 3
                     }
                 ]
             },


### PR DESCRIPTION
Some compiler warnings have additional information after the file/line number
which meant the regex wasn't matching them.

One example is:

```
warning: invalid association `account_domains` in schema Data.Schema.WebRequest: associated schema Data.Schema.AccountDomain does not have field `web_request_id`
  lib/data/schema/web_request.ex:1: Data.Schema.WebRequest (module)
```

The extra information being: `: Data.Schema.WebRequest (module)`

This change makes the matching less strict and catches any other information on the line as a message.