### PR TITLE
Add describe and test to the list of keywords

### DIFF
--- a/syntaxes/elixir.json
+++ b/syntaxes/elixir.json
@@ -105,7 +105,7 @@
       "name": "constant.other.symbol.elixir"
     },
     {
-      "match": "(?<!\\.)\\b(do|end|case|bc|lc|for|if|cond|with|unless|try|receive|fn|defmodule|defprotocol|defimpl|defrecordp?|defstruct|defdelegate|defcallback|defexception|defoverridable|exit|after|rescue|catch|else|raise|throw|quote|unquote|super|when|and|or|not|in)\\b(?![?!])",
+      "match": "(?<!\\.)\\b(do|end|case|bc|lc|for|if|cond|with|unless|try|receive|fn|defmodule|defprotocol|defimpl|defrecordp?|defstruct|defdelegate|defcallback|defexception|defoverridable|exit|after|rescue|catch|else|raise|throw|quote|unquote|super|when|and|or|not|in|describe|test)\\b(?![?!])",
       "name": "keyword.control.elixir"
     },
     {


### PR DESCRIPTION
Added `describe` and `test` to the list of keywords in order to differentiate them when using syntax highlighting.