### PR TITLE
find-all-references

### DIFF
--- a/src/EngineOptions.ts
+++ b/src/EngineOptions.ts
@@ -1,0 +1,34 @@
+'use strict';
+
+export class EngineOptions {
+
+    /**
+     * Which engine to use for the search ie. ag , rg etc ...
+     */
+    private engine: string;
+
+    /**
+     * String of shell params passed into the engine
+     */
+    private options: string;
+
+    /**
+     * @param engine Engine to be used
+     * @param options Options passed trough
+     */
+    constructor(engine: string, options: string)
+    {
+        this.engine = engine;
+        this.options = options;
+    }
+
+    public getEngine(): string
+    {
+        return this.engine;
+    }
+
+    public getOptions(): string
+    {
+        return this.options;
+    }
+}

--- a/src/ReferenceProvider.ts
+++ b/src/ReferenceProvider.ts
@@ -1,0 +1,84 @@
+'use strict';
+
+import * as vscode from 'vscode';
+import * as child_process from 'child_process';
+import { EngineOptions } from './EngineOptions';
+
+
+export class ReferenceProvider implements vscode.ReferenceProvider {
+    public provideReferences(
+        document: vscode.TextDocument, position: vscode.Position,
+        options: { includeDeclaration: boolean }, token: vscode.CancellationToken):
+        Thenable<vscode.Location[]> {
+
+        return this.getEngineOptions().then((engineOptions) => {
+            return this.processSearch(document, position, engineOptions);
+        });
+    }
+
+    private getEngineOptions(): Promise<EngineOptions> {
+        return new Promise<EngineOptions>((resolve, reject) => {
+
+            const engine = vscode.workspace.getConfiguration().get<string>('find.all.references.engine');
+            let engine_options = vscode.workspace.getConfiguration().get<string>('find.all.references.options');
+            if (engine && engine.length<1) {
+                reject(new Error('Error'));
+            }
+            if (!engine_options) { engine_options = ""}
+            // --column is hardcoded because its mandatory for now
+            const options = '--column '+engine_options;
+
+            // Note to self: if we pass in the additional space after the shell execution, command doesn't get executed correctly when the argument has an extra space.
+            // `rg --column` and not `rg --column `
+            return resolve(new EngineOptions(engine === undefined? 'rg': engine, options.trim()));
+        });
+    }
+
+    private processSearch(document, position, options): Thenable<vscode.Location[]>
+    {
+        return new Promise<vscode.Location[]>((resolve, reject) => {
+            let searchTerm = document.getText(document.getWordRangeAtPosition(position));
+            
+            //Added by Speedkore for search selected test if exist, instead of word under cursor
+            let editor =  vscode.window.activeTextEditor
+            let selection = editor.selection
+            let selectedText = editor.document.getText(selection); 
+            if(selectedText){searchTerm = selectedText}
+            // End Speedkore
+
+
+            let args = options.getOptions().split(' ');
+            args.push(searchTerm);
+            args.push(vscode.workspace.rootPath);
+            // TODO : Introduce the ability to choose different search options ripgrep, silver searcher, git grep, platinum searcher etc
+            let rg = child_process.spawnSync(options.getEngine(), args);
+            let lines = rg.stdout.toString().split('\n');
+            let list = [];
+
+            lines.forEach((item) => {
+                let arr = item.split(":");
+
+                if (arr.length>2) {
+                    // In case of drive letter
+                    if (arr[0].length == 1)
+                    {
+                        let path = arr.shift() + ':' + arr.shift();
+                        arr.unshift(path);
+                    }
+                    
+                    // Position starts from zero refer to vscode.d.ts
+                    let line_no = parseInt(arr[1])-1;
+                    let col_no = parseInt(arr[2])-1;
+
+                    let start_pos = new vscode.Position(line_no, col_no);
+                    let end_pos = new vscode.Position(line_no, col_no+searchTerm.length);
+                    let loc = new vscode.Location(vscode.Uri.file(arr[0]), new vscode.Range(start_pos, end_pos));
+
+                    list.push(loc);
+                }
+            });
+
+            return resolve(list);
+        });
+    }
+}

--- a/src/elixirMain.ts
+++ b/src/elixirMain.ts
@@ -12,6 +12,7 @@ import { ElixirSenseHoverProvider } from './elixirSenseHoverProvider';
 import { ElixirSenseServerProcess } from './elixirSenseServerProcess';
 import { ElixirSenseSignatureHelpProvider } from './elixirSenseSignatureHelpProvider';
 import { ElixirServer } from './elixirServer';
+import { ReferenceProvider } from './ReferenceProvider';
 
 const ELIXIR_MODE: vscode.DocumentFilter = { language: 'elixir', scheme: 'file' };
 // tslint:disable-next-line:prefer-const
@@ -59,6 +60,10 @@ export function activate(ctx: vscode.ExtensionContext) {
             () => selectElixirSenseWorkspaceFolder(ctx, env)));
     }
     ctx.subscriptions.push(...disposables);
+    ctx.subscriptions.push(
+        vscode.languages.registerReferenceProvider(
+            "elixir", new ReferenceProvider()));
+
 }
 
 export function deactivate() {


### PR DESCRIPTION
Hi fr1zle, i tried my best to do something with the find all references option aka: shift+f12

I realized that the problem is that elixir-sense doesn't have any option to search for references, so maybe it should be opened an issue in their repository for them to make it and then implement it here.

In the meantime, i found this https://marketplace.visualstudio.com/items?itemName=gayanhewa.referenceshelper to do the work, but it's not all that good because it doesn't support Elixir, again another issue should be made there too.

At the end, i took that code of the url and fast adapted it to your project, and it works very well and it's very handy!. 
- That code has 2 settings options that need to be adapted to your settings, for setting the "grep" system command, it supports rg(ripgrep) and ag. Default is rg (ripgrep), you can install that package from your OS repo, it's very very fast searching.
- I added 3 more lines of code that if user have something selected, it searches the selected text instead of the word under the cursor when pressing shift+f12

It's up to you, do what you want with this pull request, i don't know if you have to ask permission for using the code of the other guy Edit: he have license MIT, so we can use it, but mention him in the code or where is needed



