### PR TITLE
Add configuration for 'elixir' command

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,6 +130,11 @@
           "default": true,
           "description": "Automatically handle spawning of elixir-sense servers for each folder in the workspace"
         },
+        "elixir.command": {
+          "type": "string",
+          "default": "elixir",
+          "description": "Command to be run for launching the elixir_sense server providing intellisense features. Defaults to 'elixir'"
+        },
         "elixir.elixirEnv": {
           "type": "string",
           "default": "dev",

--- a/src/elixirMain.ts
+++ b/src/elixirMain.ts
@@ -48,7 +48,7 @@ export function activate(ctx: vscode.ExtensionContext) {
       }
     });
   } else {
-    this.elixirServer = new ElixirServer();
+    this.elixirServer = new ElixirServer(elixirSetting.command);
     this.elixirServer.start();
     ctx.subscriptions.push(vscode.languages.registerCompletionItemProvider(ELIXIR_MODE, new ElixirAutocomplete(this.elixirServer), '.'));
     ctx.subscriptions.push(vscode.languages.registerDefinitionProvider(ELIXIR_MODE, new ElixirDefinitionProvider(this.elixirServer)));
@@ -83,7 +83,8 @@ function startElixirSenseServerForWorkspaceFolder(workspaceFolder: vscode.Worksp
     return;
   }
   let subscriptions;
-  const elixirSenseServer = new ElixirSenseServerProcess(projectPath, (host, port, authToken) => {
+  const elixirSetting = vscode.workspace.getConfiguration('elixir');
+  const elixirSenseServer = new ElixirSenseServerProcess(elixirSetting.command, projectPath, (host, port, authToken) => {
     const elixirSenseClient = new ElixirSenseClient(host, port, authToken, env, projectPath);
     elixirSenseClients[projectPath] = elixirSenseClient;
     const autoCompleteProvider = new ElixirSenseAutocompleteProvider(elixirSenseClient);

--- a/src/elixirSenseServerProcess.ts
+++ b/src/elixirSenseServerProcess.ts
@@ -12,10 +12,8 @@ export class ElixirSenseServerProcess {
   ready;
   proc;
   args;
-  command;
 
-  constructor(public projectPath: string, public onTcpServerReady) {
-    this.command = 'elixir';
+  constructor(private command: string, public projectPath: string, public onTcpServerReady) {
     const extensionPath = vscode.extensions.getExtension('mjmcloug.vscode-elixir').extensionPath;
     this.args = [path.join(extensionPath, 'elixir_sense/run.exs')];
     this.proc = null;

--- a/src/elixirServer.ts
+++ b/src/elixirServer.ts
@@ -4,7 +4,6 @@ import * as vscode from 'vscode';
 
 export class ElixirServer {
   p: cp.ChildProcess;
-  command: string;
   args: string[];
   env: string;
   busy: boolean;
@@ -13,7 +12,7 @@ export class ElixirServer {
   lastRequestType: string;
   resultCallback: (result: string) => void;
 
-  constructor() {
+  constructor(private command: string) {
     const extensionPath: string = vscode.extensions.getExtension('mjmcloug.vscode-elixir').extensionPath;
     this.command = 'elixir';
     this.args = [path.join(extensionPath, 'alchemist-server/run.exs')];


### PR DESCRIPTION
This adds a new configuration allowing users to change the command used
to launch elixir_sense and alchemist-server.

`elixir` remains the default. Users without a need won't notice a
change.

Closes #109