### PR TITLE
Add doctest snippet

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -119,6 +119,12 @@
     "description": "doc",
     "scope": "source.elixir"
   },
+  "doctest": {
+    "prefix": "@doctest",
+    "body": "@doc \"\"\"\n$0\n\n## Examples\n\n\t\tiex>\n\n\"\"\"",
+    "description": "doctest",
+    "scope": "source.elixir"
+  },
   "i": {
     "prefix": "i",
     "body": "inspect($0)",


### PR DESCRIPTION
I created an issue (See here: https://github.com/fr1zle/vscode-elixir/issues/130 ) about adding a default snippet for doctests/examples.  This pull request contains exactly that snippet if you agree that it will bring value.