### PR TITLE
Improve formatter

### DIFF
--- a/src/elixirFormatter.ts
+++ b/src/elixirFormatter.ts
@@ -1,47 +1,53 @@
+'use strict';
+
 import cp = require('child_process');
-import * as vscode from 'vscode';
+import path = require('path');
+import vscode = require('vscode');
 
 export class ElixirFormatterProvider implements vscode.DocumentFormattingEditProvider {
-  provideDocumentFormattingEdits(
-    document: vscode.TextDocument,
-    options: vscode.FormattingOptions,
-    token: vscode.CancellationToken
-  ): vscode.TextEdit[] | Thenable<vscode.TextEdit[]> {
-    return document.save().then(() => {
-      return formatDocument(document);
+
+  public provideDocumentFormattingEdits(document: vscode.TextDocument, options: vscode.FormattingOptions, token: vscode.CancellationToken): Thenable<vscode.TextEdit[]> {
+    return this.runFormatter(document, token).then(edits => edits, err => {
+      const message = `Can not format due to syntax errors: ${err}`;
+
+      console.log(err);
+      vscode.window.showErrorMessage(message);
+      return Promise.reject(message);
     });
   }
-}
 
-const formatDocument = (document: vscode.TextDocument): Thenable<vscode.TextEdit[]> => {
-  return new Promise((resolve, reject) => {
-    const filename = document.fileName;
-    const checkVersion = `elixir --version`;
-    const cmd = `mix format ${document.fileName}`;
-    console.log(`cmd line:${cmd}`);
-    const cwd = vscode.workspace.rootPath ? vscode.workspace.rootPath : '';
-    cp.exec(checkVersion, { cwd }, (versionError, versionStdout, versionStderr) => {
-      if (versionError !== null) {
-        const message = `Cannot format due to syntax errors.: ${versionStderr}`;
-        console.log(`exec error: ${versionStderr}`);
-        vscode.window.showErrorMessage(message);
-        return reject(message);
-      } else {
-        if (versionStdout.indexOf('Elixir 1.6') !== -1) {
-          cp.exec(cmd, { cwd }, (error, stdout, stderr) => {
-            if (error !== null) {
-              const message = `Cannot format due to syntax errors.: ${stderr}`;
-              console.log(`exec error: ${stderr}`);
-              vscode.window.showErrorMessage(message);
-              return reject(message);
-            } else {
-              return resolve();
-            }
-          });
-        } else {
-          reject('version 1.6 is required to format');
+  private runFormatter(document: vscode.TextDocument, token: vscode.CancellationToken): Thenable<vscode.TextEdit[]> {
+    return new Promise<vscode.TextEdit[]>((resolve, reject) => {
+      const cwd = path.dirname(document.fileName);
+      const p = cp.spawn('mix', ['format', '-'], { cwd });
+      let stdout = '';
+      let stderr = '';
+
+      // Kill the formatter process if the formatter is canceled by some reason.
+      token.onCancellationRequested(() => !p.killed && p.kill());
+      // Fetch stdout and stderr from the formatter process.
+      p.stdout.setEncoding('utf8');
+      p.stdout.on('data', data => stdout += data);
+      p.stderr.on('data', data => stderr += data);
+      // Abort the formatting if the formatter process errors.
+      p.on('error', err => { return reject(); });
+      // Replace the editor text with formatted code once the formatter finishes. We return the
+      // complete file content in the edit. VS Code will calculate the minimall edits to be applied.
+      p.on('close', code => {
+        if (code !== 0) {
+          return reject(stderr);
         }
+        const fileStart = new vscode.Position(0, 0);
+        const fileEnd = document.lineAt(document.lineCount - 1).range.end;
+        const textEdits: vscode.TextEdit[] = [new vscode.TextEdit(new vscode.Range(fileStart, fileEnd), stdout)]
+
+        return resolve(textEdits);
+      });
+      // Once the process is running, pass the entire document text to it so it gets formatted.
+      if (p.pid) {
+        p.stdin.end(document.getText());
       }
     });
-  });
-};
+  }
+
+}

--- a/src/elixirFormatter.ts
+++ b/src/elixirFormatter.ts
@@ -30,7 +30,7 @@ export class ElixirFormatterProvider implements vscode.DocumentFormattingEditPro
       p.stdout.on('data', data => stdout += data);
       p.stderr.on('data', data => stderr += data);
       // Abort the formatting if the formatter process errors.
-      p.on('error', err => { return reject(); });
+      p.on('error', err => reject());
       // Replace the editor text with formatted code once the formatter finishes. We return the
       // complete file content in the edit. VS Code will calculate the minimall edits to be applied.
       p.on('close', code => {


### PR DESCRIPTION
The previous code formatter introduced in #102 was triggered after a file was saved to the
disk.
After that, the `mix format` command was run on that file, formatting its content and changing them on the disk. At last, VSCode reloaded the file with the updated contents.

This approach had two major drawbacks:
- The whole process is slow and has a delay of about 1 second on every file save.
- Since the changes to the file happen outside of the editor, we break the undo feature and cause some trouble with other extensions that rely on reproducible text editions such as [live-share][1].

This PR updates the formatter provider code to work in a similar way as the [Go][2] one does (officially implemented by Microsoft themselves). Meaning:
1. When saving the file, a `mix format -` process is spawned.
2. STDIO is used to communicate with the format process. The code to format is passed in STDIN and the formatted code is received in STDOUT. The format process is finished after that.
3. The formatted code is wrapped into a `TextEdit` object and returned. VSCode will then calculate the minimal diff to apply.
4. The file is saved to the disk with the formatting applied.

This results in a faster formatting and allows undoing the formatter using ctrl+Z. Since we are using the standard `TextEdit` objets from VSCode API, only minimal changes are applied in the editor window and they can be synchronized in live-share sessions.

[1]: https://github.com/MicrosoftDocs/live-share
[2]: https://github.com/Microsoft/vscode-go/blob/master/src/goFormat.ts