### PR TITLE
Fix problem #144

### DIFF
--- a/html.eex.configuration.json
+++ b/html.eex.configuration.json
@@ -1,6 +1,6 @@
 {
   "comments": {
-    "blockComment": ["<%#", "%>"]
+    "blockComment": ["<!--", "-->"]
   },
   "brackets": [["<", ">"], ["{", "}"], ["(", ")"], ["[", "]"]],
   "autoClosingPairs": [


### PR DESCRIPTION
As using `<%# some content %>` as block comment doesn't really work well in `.html.eex` templates i changed them to the normal html block comment tags.

Comments before (wrong):
`<%# <%= form_for @conn, initiate_path(@conn, :create), [errors: @conn.assigns[:errors]], fn f -> %> %>`
Comments now (right):
`    <!-- <%= form_for @conn, initiate_path(@conn, :create), [errors: @conn.assigns[:errors]], fn f -> %> -->`

Commenting in `.html.eex` templates now works as it should for me.