### PR TITLE
Updates `package.json` to use `prepare` instead of `postinstall`

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
   "scripts": {
     "vscode:prepublish": "tsc -p ./",
     "compile": "tsc -watch -p ./",
-    "postinstall": "node ./node_modules/vscode/bin/install",
+    "prepare": "node ./node_modules/vscode/bin/install",
     "test": "node ./node_modules/vscode/bin/test",
     "build": "vsce package",
     "lint": "tslint --project ."


### PR DESCRIPTION
The npm `postinstall` script runs both on local npm install as well as
after being installed as a dependency of someone else’s project. The
`prepare` script only runs on local npm install (and before publishing).
[npm-scripts](https://docs.npmjs.com/cli/v6/using-npm/scripts)

`vscode` is a `devDependency`, not a `dependency`, so if someone tries to
install this package as a dependency of their own, the installation
fails because `./node_modules/vscode` does not exist.

One example of where it may be useful to install the package directly
would be when using something like
[andrewbranch/gatsby-remark-vscode](https://github.com/andrewbranch/gatsby-remark-vscode)
which uses VS Code syntax highlighting and themes to generate the syntax
highlighting in Gatsby sites.

The `postinstall` to `prepare` change is
[suggested](https://github.com/andrewbranch/gatsby-remark-vscode/issues/129)
by the author of the Gatsby plugin as a way to work with languates that
aren't supported by VS Code out-of-the-box.

This change seems to have works successfully in the past for other VS
Code extensions as well:

* https://github.com/juanfranblanco/vscode-solidity/pull/186
* https://github.com/styled-components/vscode-styled-components/pull/203

## Testing

After making this change, I was able to add this package as a dependency of my Gatsby project
and successfully have the `gatsby-remark-vscode` plugin highlight Elixir syntax. 

I also tested that the `build` script still worked:

```
› npm run build

> vscode-elixir@1.1.0 build /path/to/package
> vsce package

Executing prepublish script 'npm run vscode:prepublish'...

> vscode-elixir@1.1.0 vscode:prepublish /path/to/package
> tsc -p ./

Created: ./vscode-elixir/vscode-elixir-1.1.0.vsix
```

with this I was able to manually add the `vsix` file to VS Code to install the extension.

Are there any other suggestions or practices to best test this? 
